### PR TITLE
Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ module.exports = {
 After that, you'll have a set of utilities classes you can use to show the placeholder:
 
 ```
-<div :class="{ 'cp-paragrah': isLoading }">
+<div :class="{ 'cp-paragraph': isLoading }">
   {{ content }}
 </div>
 ```


### PR DESCRIPTION
There is a typo in your quickstart doc, which leads to the fact that the example does not work. `paragrah` should be `paragraph` to make the example work.