### PR TITLE
Encode SVG url

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ module.exports = function (userOptions = {}) {
       rows.length === 1 ? renderSingleLine(rows[0]) : renderRowsOfLines(rows)
     }</svg>`;
 
-    return `url("data:image/svg+xml;utf8,${svg}")`;
+    return `url("data:image/svg+xml;utf8,${encodeURIComponent(svg)}")`;
   }
 
   return function ({ addBase, addComponents }) {


### PR DESCRIPTION
Fix for #4

This was breaking in Next@12 and was prevented from upgrading. 

Encoding the SVG data URI fixes the issue.

